### PR TITLE
Build requirements and Cython type correction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "numpy", "cython"]
+build-backend = "setuptools.build_meta"

--- a/src/tmgen/models.pxd
+++ b/src/tmgen/models.pxd
@@ -16,3 +16,5 @@ cpdef TrafficMatrix spike_tm(int num_pops, int num_spikes, double mean_spike,
                              int num_epochs=*)
 cpdef TrafficMatrix gravity_tm(populations, double total_traffic)
 cpdef TrafficMatrix exact_tm(int num_pops, double val, int num_epochs=*)
+cpdef TrafficMatrix lognormal_tm(int num_pops, double mean_traffic,
+                                 double sigma=*, int num_epochs=*)

--- a/src/tmgen/models.pyx
+++ b/src/tmgen/models.pyx
@@ -221,7 +221,16 @@ cpdef TrafficMatrix spike_tm(int num_nodes, int num_spikes, double mean_spike,
 cpdef TrafficMatrix lognormal_tm(int num_nodes, double mean_traffic,
                                  double sigma=1,
                                  int num_epochs=1):
-    return TrafficMatrix(numpy.random.lognormal(mean_traffic, sigma=sigma,
+    """
+    Lognormal traffic matrix. Values are drawn from a lognormal distribution.
+
+    :param num_nodes: number of nodes in the network
+    :param mean_traffic: mean of the underlying normal distribution
+    :param sigma: standard deviation of the underlying normal distribution
+    :param num_epochs: number of epochs in the traffic matrix
+    :return: TrafficMatrix object
+    """
+    return TrafficMatrix(numpy.random.lognormal(mean=mean_traffic, sigma=sigma,
                                                 size=(num_nodes, num_nodes,
                                                       num_epochs)).clip(min=0))
 
@@ -240,4 +249,4 @@ cpdef TrafficMatrix exact_tm(int num_nodes, double val, int num_epochs=1):
     return TrafficMatrix(numpy.ones((num_nodes, num_nodes, num_epochs)) * val)
 
 __all__ = ['modulated_gravity_tm', 'random_gravity_tm', 'gravity_tm',
-           'uniform_tm', 'exp_tm', 'spike_tm', 'exact_tm']
+           'uniform_tm', 'exp_tm', 'spike_tm', 'exact_tm', 'lognormal_tm']

--- a/src/tmgen/models.pyx
+++ b/src/tmgen/models.pyx
@@ -7,7 +7,8 @@ from six.moves import range
 from tmgen.exceptions import TMgenException
 from tmgen.tm cimport TrafficMatrix
 
-cdef numpy.ndarray _peak_mean_cycle(double freq, double n, double mean,
+fix. line 44: numpy.linspace(), n must be integer
+cdef numpy.ndarray _peak_mean_cycle(double freq, int n, double mean,
                                     double peak_to_mean,
                                     double trough_to_mean=numpy.nan):
     """

--- a/src/tmgen/models.pyx
+++ b/src/tmgen/models.pyx
@@ -7,7 +7,6 @@ from six.moves import range
 from tmgen.exceptions import TMgenException
 from tmgen.tm cimport TrafficMatrix
 
-fix. line 44: numpy.linspace(), n must be integer
 cdef numpy.ndarray _peak_mean_cycle(double freq, int n, double mean,
                                     double peak_to_mean,
                                     double trough_to_mean=numpy.nan):


### PR DESCRIPTION
This pull request includes three distinct fixes/enhancements:

1. The `setup.py` script requires importing `numpy` and `cython` early in the script's execution to configure the Cython extensions (`numpy.get_include()`, `cythonize()`). However, these packages were not automatically present within the isolated build environment used by pip and the `setuptools.build_meta` backend for collecting build requirements, even if they were installed in the user's main environment. This fix adds `numpy` and `cython` to the `[build-system].requires` list in `pyproject.toml`. This explicitly declares them as necessary dependencies for *performing the build itself*, ensuring they are installed within the isolated build environment before `setup.py` is evaluated for configuration and build requirements.
2. The `_peak_mean_cycle` function in `src/tmgen/models.pyx` uses `numpy.linspace(..., n, ...)` where the `n` argument is expected by `numpy.linspace` to be an integer. However, the Cython function signature declared `n` as a `double` (`cdef numpy.ndarray _peak_mean_cycle(double freq, double n, ...)`). If `n` were passed as a non-integer `double`, this would lead to a `TypeError` at runtime when calling `numpy.linspace`.  The type of the `n` parameter in the `cdef` function signature for `_peak_mean_cycle` has been changed from `double` to `int`.
3. The lognormal_tm traffic matrix generation function was implemented in src/tmgen/models.pyx but was not properly exposed as part of the public API of the tmgen.models module. This meant it couldn't be reliably imported and used (e.g., from tmgen.models import lognormal_tm).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/progwriter/TMgen/8)
<!-- Reviewable:end -->
